### PR TITLE
input parser: Add '--tumor-sample' argument and support for VarDict

### DIFF
--- a/parser/README.md
+++ b/parser/README.md
@@ -73,6 +73,10 @@ Usage
                             if no CNVs, need not specify argument. (default: 1.0)
       -v {sanger,oncoscan,mutect}, --variant-type {sanger,oncoscan,mutect}
                             Type of VCF file (default: None)
+      --tumor-sample TUMOR_SAMPLE
+                            Name of the tumor sample in the input VCF file.
+                            Defaults to last sample if not specified. (default:
+                            None)
       --cnv-confidence CNV_CONFIDENCE
                             Confidence in CNVs. Set to < 1 to scale "d" values
                             used in CNV output file (default: 1.0)

--- a/parser/README.md
+++ b/parser/README.md
@@ -71,7 +71,7 @@ Usage
                             Fraction of sample that is cancerous rather than
                             somatic. Used only for estimating CNV confidence --
                             if no CNVs, need not specify argument. (default: 1.0)
-      -v {sanger,oncoscan,mutect}, --variant-type {sanger,oncoscan,mutect}
+      -v, --variant-type {sanger,mutect_pcawg,mutect_smchet,muse,dkfz,vardict}
                             Type of VCF file (default: None)
       --tumor-sample TUMOR_SAMPLE
                             Name of the tumor sample in the input VCF file.

--- a/parser/create_phylowgs_inputs.py
+++ b/parser/create_phylowgs_inputs.py
@@ -203,6 +203,16 @@ class MutectSmchetParser(VariantParser):
 
     return (ref_reads, total_reads)
 
+class VarDictParser(MutectSmchetParser):
+  """Support VarDict somatic variant caller.
+
+  https://github.com/AstraZeneca-NGS/VarDictJava
+  https://github.com/AstraZeneca-NGS/VarDict
+
+  Uses the same read-extraction logic as MuTect (SMC-Het).
+  """
+  pass
+
 class DKFZParser(VariantParser):
   def __init__(self, vcf_filename, tumor_sample=None):
     self._vcf_filename = vcf_filename
@@ -685,7 +695,7 @@ def main():
     help='Output destination for variants')
   parser.add_argument('-c', '--cellularity', dest='cellularity', type=restricted_float, default=1.0,
     help='Fraction of sample that is cancerous rather than somatic. Used only for estimating CNV confidence -- if no CNVs, need not specify argument.')
-  parser.add_argument('-v', '--variant-type', dest='input_type', required=True, choices=('sanger', 'mutect_pcawg', 'mutect_smchet','muse','dkfz'),
+  parser.add_argument('-v', '--variant-type', dest='input_type', required=True, choices=('sanger', 'mutect_pcawg', 'mutect_smchet','muse','dkfz', 'vardict'),
     help='Type of VCF file')
   parser.add_argument('--tumor-sample', dest='tumor_sample',
     help='Name of the tumor sample in the input VCF file. Defaults to last sample if not specified.')
@@ -716,6 +726,8 @@ def main():
     variant_parser = MuseParser(args.vcf_file,args.tier, args.tumor_sample)
   elif args.input_type == 'dkfz':
     variant_parser = DKFZParser(args.vcf_file, args.tumor_sample)
+  elif args.input_type == 'vardict':
+    variant_parser = VarDictParser(args.vcf_file, args.tumor_sample)
   variants_and_reads = variant_parser.list_variants()
   grouper.add_variants(variants_and_reads)
 

--- a/posterior_trees.py
+++ b/posterior_trees.py
@@ -106,7 +106,10 @@ def compute_lineages(archive_fn, num_trees, fin1, fin2):
 		script_dir = os.path.dirname(os.path.realpath(__file__))
 		old_wd = os.getcwd()
 		os.chdir(script_dir)
-		call(['pdflatex', '-interaction=nonstopmode', '-output-directory=%s/posterior_trees/' % old_wd, '%s/%s' % (old_wd, tex_fn)])
+		try:
+			call(['pdflatex', '-interaction=nonstopmode', '-output-directory=%s/posterior_trees/' % old_wd, '%s/%s' % (old_wd, tex_fn)])
+		except OSError:  # pdflatex not available, do not die
+			pass
 		os.chdir(old_wd)
 
 		fidx+=1

--- a/printo.py
+++ b/printo.py
@@ -40,7 +40,10 @@ def print_top_trees(tree_archive,fout,k=5):
 			script_dir = os.path.dirname(os.path.realpath(__file__))
 			old_wd = os.getcwd()
 			os.chdir(script_dir)
-			call(['pdflatex', '-interaction=nonstopmode', '-output-directory=%s/top_trees/' % old_wd, '%s/%s' % (old_wd, tex_fn)])
+			try:
+                                call(['pdflatex', '-interaction=nonstopmode', '-output-directory=%s/top_trees/' % old_wd, '%s/%s' % (old_wd, tex_fn)])
+			except OSError:  # pdflatex not available, do not die
+                                pass
 			os.chdir(old_wd)
 			
 	tree_reader.close()


### PR DESCRIPTION
Thanks for making PhyloWGS available and for all the helpful code and documentation to get started.

This commit adds support for the VarDictJava variant caller (https://github.com/AstraZeneca-NGS/VarDictJava). As part of this, it includes an additional argument, `--tumor-sample` which specifies the name of the sample to treat as tumor. This generalizes the current parsing to support cases where the tumor isn't the last sample in the input VCF.

Thanks again.