### PR TITLE
Ignore standard virtual environment folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.o
 *.pyc
+venv
+env


### PR DESCRIPTION
These folders are wildly used to isolate Python environments into project-specific folders and looks like these were not being ignored by default. Adding them to the ignore list for convenience.