### PR TITLE
TitanCNA has changed the column names.

### DIFF
--- a/parser/parse_cnvs.py
+++ b/parser/parse_cnvs.py
@@ -64,12 +64,12 @@ class TitanParser(CnvParser):
       for record in reader:
         chrom = record['Chromosome'].lower()
         cnv = {}
-        cnv['start'] = int(record['Start_Position(bp)'])
-        cnv['end'] = int(record['End_Position(bp)'])
+        cnv['start'] = int(record['Start_Position.bp.'])
+        cnv['end'] = int(record['End_Position.bp.'])
         cnv['major_cn'] = int(record['MajorCN'])
         cnv['minor_cn'] = int(record['MinorCN'])
 
-        clonal_freq = record['Clonal_Frequency']
+        clonal_freq = record['Cellular_Prevalence']
         if clonal_freq == 'NA':
           cnv['cellular_prevalence'] = self._cellularity
         else:


### PR DESCRIPTION
Dear all,

At present, TitanCNA has changed the column names in their output files. 
So, the parser will throw out "**KeyError: 'Start_Position(bp)'**" etc.

I have made some changes in the **parse_cnvs.py**. The old column names have been changed to the new ones.
Wish it may be helpful.

If an example file is needed, I can provide it.

Thanks.